### PR TITLE
Add 'entity' parameter to OnMaintenance function

### DIFF
--- a/lua/entities/lvs_plane_p47/init.lua
+++ b/lua/entities/lvs_plane_p47/init.lua
@@ -47,7 +47,7 @@ function ENT:OnSpawn( PObj )
 	end
 end
 
-function ENT:OnMaintenance()
+function ENT:OnMaintenance(entity)
 	if not self.MISSILE_ENTITIES then return end
 
 	for _, Missile in pairs( self.MISSILE_ENTITIES ) do

--- a/lua/entities/lvs_plane_p51/init.lua
+++ b/lua/entities/lvs_plane_p51/init.lua
@@ -37,7 +37,7 @@ function ENT:OnSpawn( PObj )
 	end
 end
 
-function ENT:OnMaintenance()
+function ENT:OnMaintenance(entity)
 	if not self.MISSILE_ENTITIES then return end
 
 	for _, Missile in pairs( self.MISSILE_ENTITIES ) do

--- a/lua/entities/lvs_plane_stuka/init.lua
+++ b/lua/entities/lvs_plane_stuka/init.lua
@@ -52,7 +52,7 @@ function ENT:OnCollision( data, physobj )
 	return false
 end
 
-function ENT:OnMaintenance()
+function ENT:OnMaintenance(entity)
 	self:SetBodygroup( 6, 1 )
 end
 

--- a/lua/entities/lvs_plane_template/init.lua
+++ b/lua/entities/lvs_plane_template/init.lua
@@ -88,7 +88,8 @@ function ENT:OnEngineActiveChanged( Active )
 end
 
 -- called by the vehicle repair trailer after a repair/refil is performed
-function ENT:OnMaintenance()
+-- entity is the entity that is performing the repair/refil
+function ENT:OnMaintenance(entity)
 end
 
 --[[


### PR DESCRIPTION
Updated the OnMaintenance function in multiple plane entity scripts to include an 'entity' parameter. This change provides context about the entity performing maintenance, improving functionality and consistency across the codebase.